### PR TITLE
Fix divbyzero plugin in Bazel and IntelliJ build

### DIFF
--- a/divbyzero-plugin/src/BUILD.bazel
+++ b/divbyzero-plugin/src/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library_for_plugin_bootstrapping")
 
-scala_library(
-    name="src",
+scala_library_for_plugin_bootstrapping(
+    name = "src",
     visibility = ["//visibility:public"],
-    srcs=glob(["**/*.scala"]),
-
-    deps=[
-        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler"
+    resources = ["resources/scalac-plugin.xml"],
+    srcs = glob(["**/*.scala"]),
+    deps = [
+        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
     ]
 )

--- a/divbyzero-plugin/src/resources/scalac-plugin.xml
+++ b/divbyzero-plugin/src/resources/scalac-plugin.xml
@@ -1,0 +1,4 @@
+<plugin>
+    <name>divbyzero</name>
+    <classname>com.example.DivByZero</classname>
+</plugin>

--- a/example-for-plugin/src/BUILD.bazel
+++ b/example-for-plugin/src/BUILD.bazel
@@ -3,12 +3,9 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 scala_library(
     name="src",
     visibility = ["//visibility:public"],
-    srcs=glob(["**/*.scala"]),
-
+    srcs = glob(["**/*.scala"]),
     plugins = [
-        "//divbyzero-plugin/src:src"
+        "//divbyzero-plugin/src:src.jar",
+#        "@org_psywerx_hairyfotr_linter_2_11//jar",
     ],
-
-    deps = [
-    ]
 )


### PR DESCRIPTION
Hello,

Please see the diff for the fixes to make the Scala plugin work with your build. 

You'll need to..

* use `scala_library_for_plugin_bootstrapping` to create a special scala plugin library
* define a `scalac-plugin.xml` to contain the metadata for the Scala compiler.

<img width="1552" alt="Screen Shot 2019-07-31 at 10 05 36 PM" src="https://user-images.githubusercontent.com/347918/62260286-667c1e80-b3df-11e9-84ca-c51ef841c6f8.png">